### PR TITLE
sprint8-viewToController

### DIFF
--- a/src/main/java/etu/sprint/framework/utils/ModelView.java
+++ b/src/main/java/etu/sprint/framework/utils/ModelView.java
@@ -6,6 +6,7 @@ public class ModelView {
     
     private String view;
     private HashMap<String, Object> data = new HashMap<>();
+    private Boolean isRedirect = false;
 
     public ModelView() {}
 
@@ -32,4 +33,7 @@ public class ModelView {
     public void addItem(String key, Object value) {
         this.data.put(key, value);
     }
+
+    public boolean isRedirect() { return isRedirect; }
+    public void setRedirect(boolean redirect) { this.isRedirect = redirect; }
 }


### PR DESCRIPTION
Autoriser les méthodes des contrôleurs à déclarer un paramètre Map<String, Object> qui est automatiquement rempli à partir des paramètres de la requête HTTP, aussi bien pour les URL exactes que pour les URL correspondant à un modèle.